### PR TITLE
fix: Potential panic due to race condition

### DIFF
--- a/pkg/monitor/monitor.go
+++ b/pkg/monitor/monitor.go
@@ -81,7 +81,7 @@ func (m *Monitor) StartMonitor(interfaceName, cfgPath *string) error {
 	// listen for sigkill,term
 	signal.Notify(m.SigChan, syscall.SIGTERM, syscall.SIGKILL, syscall.SIGINT)
 
-  m.watchConfig()
+	m.watchConfig()
 	m.StartLogging(eventsChan, ringbuf)
 
 	return nil
@@ -108,9 +108,9 @@ func (m *Monitor) loadConfig(cfgPath string) error {
 	return nil
 }
 
-func (m *Monitor) watchConfig(){
-  viper.OnConfigChange(m.configChangeHandler)
-  viper.WatchConfig()
+func (m *Monitor) watchConfig() {
+	viper.OnConfigChange(m.configChangeHandler)
+	viper.WatchConfig()
 }
 
 func (m *Monitor) InitBPF(interfaceName string, bpfModule *bpf.Module) error {

--- a/pkg/monitor/monitor.go
+++ b/pkg/monitor/monitor.go
@@ -81,6 +81,7 @@ func (m *Monitor) StartMonitor(interfaceName, cfgPath *string) error {
 	// listen for sigkill,term
 	signal.Notify(m.SigChan, syscall.SIGTERM, syscall.SIGKILL, syscall.SIGINT)
 
+  m.watchConfig()
 	m.StartLogging(eventsChan, ringbuf)
 
 	return nil
@@ -104,10 +105,12 @@ func (m *Monitor) loadConfig(cfgPath string) error {
 		return err
 	}
 
-	viper.OnConfigChange(m.configChangeHandler)
-	viper.WatchConfig()
-
 	return nil
+}
+
+func (m *Monitor) watchConfig(){
+  viper.OnConfigChange(m.configChangeHandler)
+  viper.WatchConfig()
 }
 
 func (m *Monitor) InitBPF(interfaceName string, bpfModule *bpf.Module) error {


### PR DESCRIPTION
Due to the file watcher being started before pointer to BPF map is initialised, there lies a potential race condition where if the file is changed between the time where watcher is started and pointer to BPF map is initialised, there will be a panic. 

![Screenshot from 2023-08-19 16-02-49](https://github.com/DelusionalOptimist/dropit/assets/43276904/bd57e5af-570d-4aeb-8981-03a9cc202e6b)
 